### PR TITLE
Update plugin + Fix Cron Issue

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,55 +1,51 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/reminders/db" VERSION="20141211" COMMENT="XMLDB file for Moodle local/reminders"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
->
+<XMLDB xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" PATH="local/reminders/db" VERSION="20220405" COMMENT="XMLDB file for Moodle local/reminders" xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd">
   <TABLES>
     <TABLE NAME="local_reminders" COMMENT="Using to append records about reminders sent flags.">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="time" TYPE="char" LENGTH="16" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="type" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" />
+        <FIELD NAME="time" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="type" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false" />
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each local reminders cron cycle."/>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each local reminders cron cycle." />
       </KEYS>
     </TABLE>
     <TABLE NAME="local_reminders_post_act" COMMENT="Used to track send status of post activity reminders.">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="sendtime" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="eventid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" />
+        <FIELD NAME="sendtime" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="eventid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each post activity track record."/>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each post activity track record." />
       </KEYS>
     </TABLE>
     <TABLE NAME="local_reminders_activityconf" COMMENT="Used to store activity specific configs.">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="eventid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="settingkey" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="settingvalue" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" />
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="eventid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="settingkey" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="settingvalue" TYPE="text" NOTNULL="true" SEQUENCE="false" />
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each activity config."/>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="The unique id for each activity config." />
       </KEYS>
       <INDEXES>
-        <INDEX NAME="localremindercourses" UNIQUE="false" FIELDS="courseid"/>
+        <INDEX NAME="localremindercourses" UNIQUE="false" FIELDS="courseid" />
       </INDEXES>
     </TABLE>
     <TABLE NAME="local_reminders_course" COMMENT="Course specific settings whether or not send reminders.">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="status_course" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="status_activities" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="status_group" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" />
+        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" />
+        <FIELD NAME="status_course" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false" />
+        <FIELD NAME="status_activities" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false" />
+        <FIELD NAME="status_group" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="1" SEQUENCE="false" />
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="relatedcourse" TYPE="foreign-unique" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id" />
+        <KEY NAME="relatedcourse" TYPE="foreign-unique" FIELDS="courseid" REFTABLE="course" REFFIELDS="id" />
       </KEYS>
     </TABLE>
   </TABLES>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -88,6 +88,16 @@ function xmldb_local_reminders_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020032000, 'local', 'reminders');
     }
 
+    if ($oldversion < 2021092601) {
+        $table = new xmldb_table('local_reminders');
+        $field = new xmldb_field('time');
+        $field->set_attributes(XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, 10);
+        $dbman->change_field_type($table, $field);
+
+        // Reminders savepoint reached.
+        upgrade_plugin_savepoint(true, 2021092601, 'local', 'reminders');
+    }
+
     return true;
 }
 

--- a/lib.php
+++ b/lib.php
@@ -143,6 +143,7 @@ function local_reminders_cron_pre($currtime, $timewindowstart) {
     }
 
     $whereclause = '(timestart > '.$timewindowend.') AND (';
+
     $flagor = false;
     foreach ($secondsaheads as $sahead) {
         if ($flagor) {
@@ -559,14 +560,14 @@ function when_calendar_event_updated($updateevent, $changetype) {
  * Cleans the local_reminders table by deleting older unnecessary records.
  */
 function clean_local_reminders_logs() {
-    global $CFG, $DB, $PAGE;
+    global $DB;
 
     $cutofftime = time() - REMINDERS_7DAYSBEFORE_INSECONDS;
     mtrace("  [Local Reminders][CLEAN] clean cutoff time: $cutofftime");
-    $recordcount = $DB->count_records_select(REMINDERS_CLEAN_TABLE, "time >= $cutofftime");
+    $recordcount = $DB->count_records_select(REMINDERS_CLEAN_TABLE, "time >= :cutofftime", ['cutofftime' => $cutofftime]);
     if ($recordcount > 0) {
         mtrace('  [Local Reminders][CLEAN] Cleaning can be executed now as there are newer records.');
-        $deletestatus = $DB->delete_records_select(REMINDERS_CLEAN_TABLE, "time < $cutofftime");
+        $deletestatus = $DB->delete_records_select(REMINDERS_CLEAN_TABLE, "time < :cutofftime", ['cutofftime' => $cutofftime]);
         mtrace('  [Local Reminders][CLEAN] Cleaning status: '.$deletestatus);
     } else {
         mtrace('  [Local Reminders][CLEAN] No records allow to clean since reminders cron has not bee executed for long time!');

--- a/locallib.php
+++ b/locallib.php
@@ -45,16 +45,16 @@ function get_upcoming_events_for_course($courseid, $currtime) {
     global $DB;
 
     $statuses = ['due', 'close', 'course', 'expectcompletionon', 'gradingdue', 'meeting_start'];
-    list($insql, $inparams) = $DB->get_in_or_equal($statuses);
+    list($insql, $inparams) = $DB->get_in_or_equal($statuses, SQL_PARAMS_NAMED);
 
     return $DB->get_records_sql("SELECT *
         FROM {event}
-        WHERE courseid = $courseid
-            AND timestart > $currtime
+        WHERE courseid = :courseid
+            AND timestart > :timestart
             AND visible = 1
             AND eventtype $insql
         ORDER BY timestart",
-        $inparams);
+        array_merge(['courseid' => $courseid, 'timestart' => $currtime], $inparams));
 }
 
 /**
@@ -166,18 +166,19 @@ function send_overdue_activity_reminders($curtime, $timewindowstart, $activityro
 
     $rangestart = $timewindowstart;
     $statuses = ['due', 'close', 'expectcompletionon', 'gradingdue'];
-    list($insql, $inparams) = $DB->get_in_or_equal($statuses);
+    list($insql, $inparams) = $DB->get_in_or_equal($statuses, SQL_PARAMS_NAMED);
 
     $querysql = "SELECT e.*
         FROM {event} e
             LEFT JOIN {local_reminders_post_act} lrpa ON e.id = lrpa.eventid
         WHERE
-            e.timestart >= $rangestart AND e.timestart < $curtime
+            e.timestart >= :rangestart AND e.timestart < :curtime
             AND lrpa.eventid IS NULL
             AND e.eventtype $insql
             AND e.visible = 1";
 
-    $allexpiredevents = $DB->get_records_sql($querysql, $inparams);
+    $allexpiredevents = $DB->get_records_sql($querysql, array_merge(['rangestart' => $rangestart, 'curtime' => $curtime], $inparams));
+
     if (!$allexpiredevents || count($allexpiredevents) == 0) {
         mtrace('[LOCAL REMINDERS] No expired events found for this cron cycle! Skipped.');
         return;
@@ -833,7 +834,7 @@ function fetch_module_instance($modulename, $instance, $courseid=0, $showtrace=t
     try {
         return $DB->get_record_sql($sql, $params, IGNORE_MISSING);
     } catch (moodle_exception $mex) {
-        $showtrace && mtrace('  [Local Reminder - ERROR] Failed to fetch module instance! '.$mex.getMessage);
+        $showtrace && mtrace('  [Local Reminder - ERROR] Failed to fetch module instance! '.$mex->getMessage());
         return null;
     }
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021092600;
+$plugin->version   = 2021092601;
 $plugin->requires  = 2018051700;        // Require moodle 3.5 or higher.
 $plugin->release   = '2.5';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
- Updating fork to the latest version (57 commits)
- Cleaned up install.xml to be the same as XMLDB generates
- Fixed exception not being called correctly
- Fixed cron exception resulting from incorrectly configured DB types / db function usage

Plugin initially creates a 'time' field in DB as a char instead of int. When cron runs, it tries to compare a char to int and calls exception (In postgres). Plugin creator uses MySQL which implicity converts them so didn't realise. I also went through all the SQL queries and added named parameters (where possible).

In some places it wasn't possible (e.g. dynamic table names), but wasn't necessary as the parameters were not user inputs or url parameters.

Plugin creator has a WIP fix for this https://github.com/isuru89/moodle-local_reminders/pull/141 but it has been open for 14 months and not merged...